### PR TITLE
Add a description option to checks

### DIFF
--- a/app/controllers/allgood/healthcheck_controller.rb
+++ b/app/controllers/allgood/healthcheck_controller.rb
@@ -16,7 +16,7 @@ module Allgood
       Rails.logger.error "Allgood Healthcheck Error: #{e.message}\n#{e.backtrace.join("\n")}"
 
       # Return a minimal response
-      @results = [{ name: "Healthcheck Error", success: false, message: "Internal error occurred", duration: 0 }]
+      @results = [ { name: "Healthcheck Error", success: false, message: "Internal error occurred", duration: 0 } ]
       @status = "error"
 
       respond_to do |format|
@@ -35,7 +35,9 @@ module Allgood
             success: true,
             skipped: true,
             message: check[:skip_reason],
-            duration: 0
+            duration: 0,
+            context: check[:context],
+            context_url: check[:context_url]
           }
         else
           run_single_check(check)
@@ -59,12 +61,19 @@ module Allgood
           success: last_result ? last_result[:success] : true,
           skipped: true,
           message: message,
-          duration: 0
+          duration: 0,
+          context: check[:context],
+          context_url: check[:context_url]
         }
       end
 
       start_time = Time.now
-      result = { success: false, message: "Check timed out after #{check[:timeout]} seconds" }
+      result = {
+        success: false,
+        message: "Check timed out after #{check[:timeout]} seconds",
+        context: check[:context],
+        context_url: check[:context_url]
+      }
       error_key = "allgood:error:#{check[:name].parameterize}"
 
       begin
@@ -106,7 +115,9 @@ module Allgood
         name: check[:name],
         success: result[:success],
         message: result[:message],
-        duration: ((Time.now - start_time) * 1000).round(1)
+        duration: ((Time.now - start_time) * 1000).round(1),
+        context: check[:context],
+        context_url: check[:context_url]
       }
     end
   end

--- a/app/controllers/allgood/healthcheck_controller.rb
+++ b/app/controllers/allgood/healthcheck_controller.rb
@@ -16,7 +16,7 @@ module Allgood
       Rails.logger.error "Allgood Healthcheck Error: #{e.message}\n#{e.backtrace.join("\n")}"
 
       # Return a minimal response
-      @results = [ { name: "Healthcheck Error", success: false, message: "Internal error occurred", duration: 0 } ]
+      @results = [{ name: "Healthcheck Error", success: false, message: "Internal error occurred", duration: 0 }]
       @status = "error"
 
       respond_to do |format|

--- a/app/controllers/allgood/healthcheck_controller.rb
+++ b/app/controllers/allgood/healthcheck_controller.rb
@@ -32,12 +32,11 @@ module Allgood
         if check[:status] == :skipped
           {
             name: check[:name],
+            description: check[:description],
             success: true,
             skipped: true,
             message: check[:skip_reason],
-            duration: 0,
-            context: check[:context],
-            context_url: check[:context_url]
+            duration: 0
           }
         else
           run_single_check(check)
@@ -58,21 +57,19 @@ module Allgood
 
         return {
           name: check[:name],
+          description: check[:description],
           success: last_result ? last_result[:success] : true,
           skipped: true,
           message: message,
-          duration: 0,
-          context: check[:context],
-          context_url: check[:context_url]
+          duration: 0
         }
       end
 
       start_time = Time.now
       result = {
+        description: check[:description],
         success: false,
-        message: "Check timed out after #{check[:timeout]} seconds",
-        context: check[:context],
-        context_url: check[:context_url]
+        message: "Check timed out after #{check[:timeout]} seconds"
       }
       error_key = "allgood:error:#{check[:name].parameterize}"
 
@@ -113,11 +110,10 @@ module Allgood
 
       {
         name: check[:name],
+        description: check[:description],
         success: result[:success],
         message: result[:message],
-        duration: ((Time.now - start_time) * 1000).round(1),
-        context: check[:context],
-        context_url: check[:context_url]
+        duration: ((Time.now - start_time) * 1000).round(1)
       }
     end
   end

--- a/app/views/allgood/healthcheck/index.html.erb
+++ b/app/views/allgood/healthcheck/index.html.erb
@@ -32,9 +32,15 @@
       <% else %>
         <%= result[:success] ? "✅" : "❌" %>
       <% end %>
-      <b><%= result[:name] %></b>: <i><%= result[:message] %></i> 
+      <b><%= result[:name] %></b>: <i><%= result[:message] %></i>
       <% unless result[:skipped] %>
         <code>[<%= result[:duration] %>ms]</code>
+      <% end %>
+
+      <% if result[:context_url] %>
+        <i>(<a href="<%= result[:context_url] %>" target="_blank"><%= result[:context] || "see more" %></a>)</i>
+      <% elsif result[:context] %>
+        <i>(<%= result[:context] %>)</i>
       <% end %>
     </div>
   <% end %>

--- a/app/views/allgood/healthcheck/index.html.erb
+++ b/app/views/allgood/healthcheck/index.html.erb
@@ -18,6 +18,13 @@
   .skipped {
     opacity: 0.6;
   }
+
+  .description {
+    margin-left: 0.5rem;
+    border-left: gray solid 2px;
+    padding: 0.5rem 1rem;
+    opacity: 0.6;
+  }
 </style>
 
 <header>
@@ -37,10 +44,10 @@
         <code>[<%= result[:duration] %>ms]</code>
       <% end %>
 
-      <% if result[:context_url] %>
-        <i>(<a href="<%= result[:context_url] %>" target="_blank"><%= result[:context] || "see more" %></a>)</i>
-      <% elsif result[:context] %>
-        <i>(<%= result[:context] %>)</i>
+      <% if result[:description].present? %>
+        <div class="description">
+          <%= sanitize result[:description] %>
+        </div>
       <% end %>
     </div>
   <% end %>

--- a/app/views/allgood/healthcheck/index.html.erb
+++ b/app/views/allgood/healthcheck/index.html.erb
@@ -39,7 +39,7 @@
       <% else %>
         <%= result[:success] ? "✅" : "❌" %>
       <% end %>
-      <b><%= result[:name] %></b>: <i><%= result[:message] %></i>
+      <b><%= result[:name] %></b>: <i><%= result[:message] %></i> 
       <% unless result[:skipped] %>
         <code>[<%= result[:duration] %>ms]</code>
       <% end %>

--- a/lib/allgood/configuration.rb
+++ b/lib/allgood/configuration.rb
@@ -13,6 +13,8 @@ module Allgood
         name: name,
         block: block,
         timeout: options[:timeout] || @default_timeout,
+        context: options[:context],
+        context_url: options[:context_url],
         options: options,
         status: :pending
       }

--- a/lib/allgood/configuration.rb
+++ b/lib/allgood/configuration.rb
@@ -11,10 +11,9 @@ module Allgood
     def check(name, **options, &block)
       check_info = {
         name: name,
+        description: options[:description],
         block: block,
         timeout: options[:timeout] || @default_timeout,
-        context: options[:context],
-        context_url: options[:context_url],
         options: options,
         status: :pending
       }


### PR DESCRIPTION
When a check times out or raises an error, the make_sure message can't be displayed. Also, there's no way to add some kind of message to expects. While searching for a solution, I came up with the idea of a check description.
The newly added check description enables you to set a custom description (including formatting) to a check that will be shown no matter the result of the checks/expects.

<img width="950" height="642" alt="image" src="https://github.com/user-attachments/assets/5ffc7cee-1b74-4f90-bc85-0ecc4acb7b3d" />

<details>
<summary>Darkmode</summary>
<img width="948" height="675" alt="image" src="https://github.com/user-attachments/assets/df93949d-f13f-4be0-80d7-bc04c125d039" />
</details>

```rb

# config/allgood.rb

check "DB Connection", description: "Testing the db connection.<br> <b>Wow, I'm bold</b>" do
  make_sure ActiveRecord::Base.connection.connect!.active?, "I will be shown because all went well"
end

check "DB Connection", description: "This messages will be shown" do
  # raise error
  make_sure 1 > "1", "This message won't be shown"
end

check "DB Connection", description: "This messages will be shown" do
  sleep 20 # force a timeout
  make_sure ActiveRecord::Base.connection.connect!.active?, "This message won't be shown"
end

# No description box will be shown

check "DB Connection", description: "" do
  make_sure ActiveRecord::Base.connection.connect!.active?
end

check "DB Connection" do
  make_sure ActiveRecord::Base.connection.connect!.active?
end
```



